### PR TITLE
Fix order of messages in list

### DIFF
--- a/lib/handlers.js
+++ b/lib/handlers.js
@@ -28,7 +28,7 @@ module.exports = {
 		var log = ui.grid("bottom").get(0, 0)
 
 		for(var i in messages) {
-			var message = messages[i];
+			var message = messages[messages.length-1-i];
 			log.log(message.timestamp + " - " + message.message)
 		}
 


### PR DESCRIPTION
Graylog's REST API provides messages from NEW to OLD. The rolling log widget appends new messages at the bottom. This differs from the screencast GIF in the README.md. When iterating and adding messages from NEW to OLD, the message at the bottom is older than the messages above it and the newest messages may be scrolled out of the visible space.
