### PR TITLE
Syslog cli

### DIFF
--- a/lib/controller.js
+++ b/lib/controller.js
@@ -1,0 +1,74 @@
+var graylog = require("./graylog-api.js")
+var ui = require("./screen.js")
+var handlers = require("./handlers.js")
+var ticker = {
+	msg: 0,
+	stream: 0,
+	total: 0,
+	alert: 0
+}
+
+module.exports = {
+	config: {},
+	setupHandler: function() {
+		var _this=this
+		ticker.msg = setInterval(function() {
+			graylog.lastMessagesOfStream({
+				serverUrl: _this.config.serverUrl,
+				streamId: _this.config.streamId,
+				mainQuery: _this.config.mainq,
+				username: _this.config.apiUser,
+				password: _this.config.apiPass
+			}, handlers.updateMessagesList)
+		}, 1000)
+		ticker.stream = setInterval(function() {
+			graylog.streamThroughput({
+				serverUrl: _this.config.serverUrl,
+				streamId: _this.config.streamId,
+				username: _this.config.apiUser,
+				password: _this.config.apiPass
+			}, handlers.updateStreamThroughput)
+		}, 1000)
+		ticker.total = setInterval(function() {
+			graylog.totalThroughput({
+				serverUrl: _this.config.serverUrl,
+				username: _this.config.apiUser,
+				password: _this.config.apiPass
+			}, handlers.updateTotalThroughputLine)
+		}, 1000)
+		ticker.alert = setInterval(function() {
+			graylog.streamAlerts({
+				serverUrl: _this.config.serverUrl,
+				streamId: _this.config.streamId,
+				username: _this.config.apiUser,
+				password: _this.config.apiPass
+			}, handlers.renderAlerts)
+		}, 1000)
+	},
+	slaveHandler: function() {
+		var _this=this
+
+		ticker.msg = setInterval(function() {
+			graylog.lastMessagesOfStream({
+				serverUrl: _this.config.serverUrl,
+				streamId: _this.config.streamId,
+				mainQuery: _this.config.mainq,
+				username: _this.config.apiUser,
+				password: _this.config.apiPass
+			}, handlers.updateMessagesList)
+		}, 1000)
+		ticker.stream = setInterval(function() {
+			graylog.lastMessagesOfStream({
+				serverUrl: _this.config.serverUrl,
+				streamId: _this.config.slaveStream,
+				username: _this.config.apiUser,
+				password: _this.config.apiPass
+			}, handlers.updateSlaveList)
+		}, 1000)
+	},
+	resetHandler: function() {
+		for (var i in ticker) {
+			clearInterval(i);
+		}
+	}
+}

--- a/lib/graylog-api.js
+++ b/lib/graylog-api.js
@@ -41,7 +41,7 @@ module.exports = {
     var parameters = {
       query: "*",
       range: 86400,
-      fields: "timestamp,message",
+      fields: "timestamp,source,message",
       filter: "streams:" + options.streamId,
       limit: 50
     }

--- a/lib/graylog-api.js
+++ b/lib/graylog-api.js
@@ -38,10 +38,11 @@ module.exports = {
 
   lastMessagesOfStream: function(options, callback) {
     var url = options.serverUrl + "search/universal/relative"
+    if ( !options.mainQuery) options.mainQuery='*';
     var parameters = {
-      query: "*",
-      range: 86400,
-      fields: "timestamp,source,message",
+      query: options.mainQuery,
+      range: 10000,
+      fields: "_id,timestamp,source,message",
       filter: "streams:" + options.streamId,
       limit: 50
     }

--- a/lib/handlers.js
+++ b/lib/handlers.js
@@ -14,113 +14,103 @@
  * You should have received a copy of the GNU General Public License
  * along with Graylog2.  If not, see <http://www.gnu.org/licenses/>.
  */
-
-
 var moment = require('moment')
 var ui = require("./screen.js")
+var totalThroughputData = {
+	x: [],
+	y: []
+}
+var streamThroughputData = {
+	x: [],
+	y: []
+}
 
-var totalThroughputData = {x:[],y:[]}
-var streamThroughputData = {x:[],y:[]}
+function pad(n) {
+	return ("0" + n).slice(-2);
+}
+var lastId = [];
 
-module.exports = {
-
-	updateMessagesList: function(messages) {
-		var log = ui.grid("bottom")//.get(0, 0)
-
-		for(var i in messages) {
-			var message = messages[i];
-            var dtx = new Date(message.timestamp);
-            log.log(dtx.getHours()+':'+dtx.getMinutes()+':'+dtx.getSeconds()+ ' - ' + message.source + " : " + message.message)
+function procMsg(tgt, messages) {
+	var log = ui.grid(tgt); //.get(0, 0)
+	if (!lastId[tgt]) {
+		lastId[tgt] = {id: false,idAr: [], ts: false};
+	}
+	messages.reverse();
+	for (var i in messages) {
+		var message = messages[i];
+		var dtx = new Date(message.timestamp);
+		if (lastId[tgt].idAr.indexOf(message._id) == -1 ) {
+			log.log(dtx.getHours() + ':' + dtx.getMinutes() + ':' + pad(dtx.getSeconds()) + '- ' + message.source + ": " + message.message);
+			lastId[tgt].id = message._id;
+			lastId[tgt].idAr.push(message._id);
+			if ( lastId[tgt].idAr.length > 70 ) lastId[tgt].idAr.shift();
+			lastId[tgt].ts = message.timestamp;
 		}
-
-		ui.render()
+	}
+	//need modify to time range relative search
+	ui.render();
+}
+module.exports = {
+	updateMessagesList: function(messages) {
+		procMsg("bottom", messages);
 	},
-
+	updateSlaveList: function(messages) {
+		procMsg("sectop", messages);
+	},
 	updateTotalThroughputLine: function(throughput) {
-		var throughputLine = ui.grid("topRight")//.get(0, 0)
-
+		var throughputLine = ui.grid("topRight") //.get(0, 0)
 		// Manage local data array.
-		if(totalThroughputData.x.length >= 300) {
+		if (totalThroughputData.x.length >= 300) {
 			totalThroughputData.x.shift()
 			totalThroughputData.y.shift()
 		}
 		totalThroughputData.x.push(moment().format("HH:mm"))
 		totalThroughputData.y.push(throughput)
-
-/*
-		var x = []
-		var y = []
-		for(var i in totalThroughputData) {
-			x.push(totalThroughputData[i].x)
-			y.push(totalThroughputData[i].y)
-		}
-*/
-
 		throughputLine.setData(totalThroughputData) //x, y)
 		ui.render()
 	},
-
 	updateStreamThroughput: function(throughput) {
 		// Update in title of log messages widget.
-		var box = ui.grid("bottom")//.get(0, 0)
+		var box = ui.grid("bottom") //.get(0, 0)
 		box.setLabel("Messages (Throughput: " + throughput.toString() + "/sec)")
-
 		// Update in chart.
-		var throughputLine = ui.grid("top")//.get(0, 0)
-
+		var throughputLine = ui.grid("top") //.get(0, 0)
 		// Manage local data array.
-			if(streamThroughputData.x.length >= 300) {
+		if (streamThroughputData.x.length >= 300) {
 			streamThroughputData.x.shift()
 			streamThroughputData.y.shift()
 		}
-//		streamThroughputData.push({x: moment().format("HH:mm"), y: throughput})
+		//		streamThroughputData.push({x: moment().format("HH:mm"), y: throughput})
 		streamThroughputData.x.push(moment().format("HH:mm"))
 		streamThroughputData.y.push(throughput)
-/*
-
-		var x = []
-		var y = []
-		for(var i in streamThroughputData) {
-			x.push(streamThroughputData[i].x)
-			y.push(streamThroughputData[i].y)
-		}
-*/
-
 		throughputLine.setData(streamThroughputData) // x, y)
 		ui.render()
 	},
-
 	renderAlerts: function(alertList) {
-		var alerts = ui.grid("alertGrid")//topRight").get(1, 0)
+		var alerts = ui.grid("alertGrid") //topRight").get(1, 0)
 		var lines = []
-
-		if(alertList.total_triggered == 0) {
+		if (alertList.total_triggered == 0) {
 			lines.push("") // Empty line as padding.
 			lines.push("{center}{green-fg}No active alerts for this stream!{/green-fg}{/center}")
 		} else {
 			// Stream has active alerts!
 			var msg;
 			if (alertList.total_triggered == 1) {
-					msg = "One active stream alert:"
+				msg = "One active stream alert:"
 			} else {
-					msg = "Multiple (" + alertList.total_triggered + ") active stream alerts:"
+				msg = "Multiple (" + alertList.total_triggered + ") active stream alerts:"
 			}
-
 			lines.push("{center}{red-bg}!! " + msg + " !!{/red-bg}{/center}")
 			lines.push("")
-
 			// Add alerts to list.
-			for(var i in alertList.results) {
-					lines.push(buildAlertDescription(i, alertList.results[i]))
+			for (var i in alertList.results) {
+				lines.push(buildAlertDescription(i, alertList.results[i]))
 			}
-
 			lines.push("")
 			lines.push("{center}Open your Graylog web interface for alert details.{/center}")
 		}
-
 		alerts.setItems(lines)
 	}
-
 }
 
 function buildAlertDescription(i, alert) {

--- a/lib/handlers.js
+++ b/lib/handlers.js
@@ -19,55 +19,64 @@
 var moment = require('moment')
 var ui = require("./screen.js")
 
-var totalThroughputData = [ ]
-var streamThroughputData = [ ]
+var totalThroughputData = {x:[],y:[]}
+var streamThroughputData = {x:[],y:[]}
 
 module.exports = {
 
 	updateMessagesList: function(messages) {
-		var log = ui.grid("bottom").get(0, 0)
+		var log = ui.grid("bottom")//.get(0, 0)
 
 		for(var i in messages) {
 			var message = messages[i];
-			log.log(message.timestamp + " - " + message.message)
+            var dtx = new Date(message.timestamp);
+            log.log(dtx.getHours()+':'+dtx.getMinutes()+':'+dtx.getSeconds()+ ' - ' + message.source + " : " + message.message)
 		}
 
 		ui.render()
 	},
 
 	updateTotalThroughputLine: function(throughput) {
-		var throughputLine = ui.grid("topRight").get(0, 0)
+		var throughputLine = ui.grid("topRight")//.get(0, 0)
 
 		// Manage local data array.
-		if(totalThroughputData.length >= 300) {
-			totalThroughputData.shift()
+		if(totalThroughputData.x.length >= 300) {
+			totalThroughputData.x.shift()
+			totalThroughputData.y.shift()
 		}
-		totalThroughputData.push({x: moment().format("HH:mm"), y: throughput})
+		totalThroughputData.x.push(moment().format("HH:mm"))
+		totalThroughputData.y.push(throughput)
 
+/*
 		var x = []
 		var y = []
 		for(var i in totalThroughputData) {
 			x.push(totalThroughputData[i].x)
 			y.push(totalThroughputData[i].y)
 		}
+*/
 
-		throughputLine.setData(x, y)
+		throughputLine.setData(totalThroughputData) //x, y)
 		ui.render()
 	},
 
 	updateStreamThroughput: function(throughput) {
 		// Update in title of log messages widget.
-		var box = ui.grid("bottom").get(0, 0)
+		var box = ui.grid("bottom")//.get(0, 0)
 		box.setLabel("Messages (Throughput: " + throughput.toString() + "/sec)")
 
 		// Update in chart.
-		var throughputLine = ui.grid("top").get(0, 0)
+		var throughputLine = ui.grid("top")//.get(0, 0)
 
 		// Manage local data array.
-		if(streamThroughputData.length >= 300) {
-			streamThroughputData.shift()
+			if(streamThroughputData.x.length >= 300) {
+			streamThroughputData.x.shift()
+			streamThroughputData.y.shift()
 		}
-		streamThroughputData.push({x: moment().format("HH:mm"), y: throughput})
+//		streamThroughputData.push({x: moment().format("HH:mm"), y: throughput})
+		streamThroughputData.x.push(moment().format("HH:mm"))
+		streamThroughputData.y.push(throughput)
+/*
 
 		var x = []
 		var y = []
@@ -75,13 +84,14 @@ module.exports = {
 			x.push(streamThroughputData[i].x)
 			y.push(streamThroughputData[i].y)
 		}
+*/
 
-		throughputLine.setData(x, y)
+		throughputLine.setData(streamThroughputData) // x, y)
 		ui.render()
 	},
 
 	renderAlerts: function(alertList) {
-		var alerts = ui.grid("topRight").get(1, 0)
+		var alerts = ui.grid("alertGrid")//topRight").get(1, 0)
 		var lines = []
 
 		if(alertList.total_triggered == 0) {

--- a/lib/screen.js
+++ b/lib/screen.js
@@ -19,35 +19,10 @@ var blessed = require("blessed")
 
 var contrib = require("blessed-contrib")
 
-var screen = blessed.screen()
-var grid = new contrib.grid({rows: 2, cols: 1})
-var topGrid = new contrib.grid({rows: 1, cols: 2})
-var bottomGrid = new contrib.grid({rows: 1, cols: 1})
-var topRightGrid = new contrib.grid({rows: 2, cols: 1})
+var screen = blessed.screen({fullUnicode:true,smartCSR:true})
+var grid = new contrib.grid({rows: 5, cols: 2, screen:screen})
 
-// Set up widgets.
-
-topRightGrid.set(0, 0, contrib.line, {
-  label: "Total Throughput (max last 5 minutes)",
-  style: {
-    line: "green",
-    text: "green",
-    baseline: "white"
-  },
-  xLabelPadding: 10,
-  xPadding: 15,
-  showNthLabel: 60
-})
-
-topRightGrid.set(1, 0, blessed.list, {
-  label: "Alerts (30s cached)",
-  tags: true,
-  items: ["loading ..."],
-  mouse: true,
-  scrollable: true
-})
-
-topGrid.set(0, 0, contrib.line, {
+var topGrid =  grid.set(0, 0, 2, 1, contrib.line, {
   label: "Stream Throughput (max last 5 minutes)",
   style: {
     line: "red",
@@ -59,19 +34,44 @@ topGrid.set(0, 0, contrib.line, {
   showNthLabel: 60
 })
 
-bottomGrid.set(0, 0, contrib.log, {
+
+var topRightGrid = grid.set(0, 1, 1, 1, contrib.line, {
+  label: "Total Throughput (max last 5 minutes)",
+  style: {
+    line: "green",
+    text: "green",
+    baseline: "white"
+  },
+  xLabelPadding: 10,
+  xPadding: 15,
+  showNthLabel: 60
+})
+
+var alertGrid = grid.set(1,1,1,1,blessed.list, {
+  label: "Alerts (30s cached)",
+  tags: true,
+  items: ["loading ..."],
+  mouse: true,
+  scrollable: true
+})
+
+
+var bottomGrid = grid.set(2,0,3,2,contrib.log, {
   fg: "green",
   selectedFg: "green",
   bufferLength: 50,
   label: "Messages"
 })
 
+
 // Arrange grids.
 
+/*
 grid.set(0, 0, topGrid)
 grid.set(1, 0, bottomGrid)
 topGrid.set(0, 1, topRightGrid)
 grid.applyLayout(screen)
+*/
 screen.render()
 
 screen.key(['escape', 'q', 'C-c'], function(ch, key) {
@@ -94,6 +94,8 @@ module.exports = {
 				return bottomGrid;
 			case "topRight":
 				return topRightGrid;
+			case "alertGrid":
+				return alertGrid;
 		}
 	},
 

--- a/lib/screen.js
+++ b/lib/screen.js
@@ -15,92 +15,140 @@ var blessed = require("blessed")
  * You should have received a copy of the GNU General Public License
  * along with Graylog2.  If not, see <http://www.gnu.org/licenses/>.
  */
-
-
 var contrib = require("blessed-contrib")
+var graylog = require("./graylog-api.js")
 
-var screen = blessed.screen({fullUnicode:true,smartCSR:true})
-var grid = new contrib.grid({rows: 5, cols: 2, screen:screen})
 
-var topGrid =  grid.set(0, 0, 2, 1, contrib.line, {
-  label: "Stream Throughput (max last 5 minutes)",
-  style: {
-    line: "red",
-    text: "green",
-    baseline: "white"
-  },
-  xLabelPadding: 10,
-  xPadding: 15,
-  showNthLabel: 60
+
+var screen = blessed.screen({
+	fullUnicode: true,
+	smartCSR: true
 })
-
-
-var topRightGrid = grid.set(0, 1, 1, 1, contrib.line, {
-  label: "Total Throughput (max last 5 minutes)",
-  style: {
-    line: "green",
-    text: "green",
-    baseline: "white"
-  },
-  xLabelPadding: 10,
-  xPadding: 15,
-  showNthLabel: 60
+var grid = new contrib.grid({
+	rows: 6,
+	cols: 2,
+	screen: screen
 })
-
-var alertGrid = grid.set(1,1,1,1,blessed.list, {
-  label: "Alerts (30s cached)",
-  tags: true,
-  items: ["loading ..."],
-  mouse: true,
-  scrollable: true
-})
-
-
-var bottomGrid = grid.set(2,0,3,2,contrib.log, {
-  fg: "green",
-  selectedFg: "green",
-  bufferLength: 50,
-  label: "Messages"
-})
-
-
-// Arrange grids.
-
-/*
-grid.set(0, 0, topGrid)
-grid.set(1, 0, bottomGrid)
-topGrid.set(0, 1, topRightGrid)
-grid.applyLayout(screen)
-*/
-screen.render()
-
-screen.key(['escape', 'q', 'C-c'], function(ch, key) {
-  return process.exit(0);
+var sc = false, defMode = 'Default';
+var modeChooser = blessed.list({
+	parent: screen,
+	top: 'center',
+	left: 'center',
+	style: {
+		bg: 'white',
+		fg: 'blue'
+	},
+	items: ['Default', 'Security'],
+	interactive: true,
+	mouse: true,
+	keys: true
 });
-
+modeChooser.on('select', function(ev) {
+	modeChooser.toggle();
+	if (ev.content != defMode) {
+		//set new screen layout
+		try {
+			screen.remove(topGrid);
+			screen.remove(bottomGrid);
+			screen.remove(alertGrid);
+			screen.remove(topRightGrid);
+			screen.remove(sectopGrid);
+		}
+		catch(er) {}
+		var controller = require("./controller.js")
+		controller.resetHandler();
+		if (ev.content == 'Security') {
+			screen.append(bottomGrid);
+			screen.render();
+			sectopGrid = grid.set(0, 0, 2, 2, contrib.log, {
+				label: "Targeted logs",
+				fg: "red",
+				selectedFg: "red",
+				bufferLength: 150
+			});
+			controller.slaveHandler();
+		} else {
+			controller.setupHandler();
+		}
+		bottomGrid.focus()
+	}
+})
+screen.key(['s'], function(ch, key) {
+	if (!sc) {
+		screen.append(modeChooser)
+		modeChooser.show()
+		sc = true
+	} else {
+		modeChooser.toggle()
+		modeChooser.focus()
+	}
+});
+var topGrid = grid.set(0, 0, 2, 1, contrib.line, {
+	label: "Stream Throughput (max last 5 minutes)",
+	style: {
+		line: "red",
+		text: "green",
+		baseline: "white"
+	},
+	xLabelPadding: 10,
+	xPadding: 15,
+	yPadding: 0,
+	showNthLabel: 60
+})
+var sectopGrid;
+var topRightGrid = grid.set(0, 1, 1, 1, contrib.line, {
+	label: "Total Throughput (max last 5 minutes)",
+	style: {
+		fg: "green",
+		line: "green",
+		text: "green",
+		baseline: "white"
+	},
+	tags: true,
+	xLabelPadding: 10,
+	xPadding: 15,
+	yPadding: 0,
+	showNthLabel: 60
+})
+var alertGrid = grid.set(1, 1, 1, 1, blessed.list, {
+	label: "Alerts (30s cached)",
+	tags: true,
+	items: ["loading ..."],
+	mouse: true,
+	scrollable: true
+})
+var bottomGrid = grid.set(2, 0, 4, 2, contrib.log, {
+	fg: "green",
+	selectedFg: "green",
+	bufferLength: 150,
+	label: "Messages"
+})
+// Arrange grids.
+screen.render()
+screen.key(['escape', 'q', 'C-c'], function(ch, key) {
+	return process.exit(0);
+});
 module.exports = {
-
 	screen: function() {
 		return screen;
 	},
-
 	grid: function(grid) {
-		switch(grid) {
-			case "main":
-				return grid;
-			case "top":
-				return topGrid;
-			case "bottom":
-				return bottomGrid;
-			case "topRight":
-				return topRightGrid;
-			case "alertGrid":
-				return alertGrid;
+		switch (grid) {
+		case "main":
+			return grid;
+		case "top":
+			return topGrid;
+		case "bottom":
+			return bottomGrid;
+		case "topRight":
+			return topRightGrid;
+		case "alertGrid":
+			return alertGrid;
+		case "sectop":
+			return sectopGrid;
 		}
 	},
-
 	render: function() {
 		screen.render()
 	}
-
 }

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
   ],
   "version": "0.13.0",
   "dependencies": {
-    "blessed": "0.0.37",
-    "blessed-contrib": "0.0.8",
+    "blessed": "0.1.81",
+    "blessed-contrib": "2.5.2",
     "js-yaml": "^3.2.5",
     "moment": "~2.9.0",
     "request": "~2.51.0",


### PR DESCRIPTION
```
1. syslog_cli version got new screen layout. …
```

Short key : S  change screen layout.

temporary name (security) panel uses second stream.

./graylog-dashboard --stream-id [main streamid] --mainq  [main query filter] --slave [second streamid]
1. Performance targeted to syslog or such like things

more small cpu utilization for node process.

Original version : Every 1 seconds, get 50 limited log 1days range. putting whole 50 lines of log to bottom log panel, (causes scrolling, panel redrawing)

This version : Every 1 seconds, get 50 limited log from 10000 seconds range, processing message id, put unattended message to log (while processing this case, possible to display some of delayed log, it is not sort order relate problems.)

using local time, reversed display order, low cpu usage, can processing max 70 message per seconds. not suitable for web logs.
