### PR TITLE
Make port coercion slightly more compatible with urls ending in /api/

### DIFF
--- a/graylog-dashboard.js
+++ b/graylog-dashboard.js
@@ -88,7 +88,8 @@ function getOptions() {
     // Make sure we have a protocol (default: https)
     if (config.serverURL.slice(0, 4) !== 'http') config.serverURL = 'https://' + config.serverURL;
     // Make sure we have a port (default REST API port is 12900)
-    if (!/:\d+$/.test(config.serverURL)) config.serverURL += ':12900';
+    // this only works for urls that do not end in /api or specify a port.
+    if (!/:\d+/.test(config.serverURL)) config.serverURL += ':12900';
     // Make sure config.serverURL has a trailing slash. (computers.)
     if (config.serverURL[config.serverURL.length - 1] !== '/') config.serverURL += '/';
     return config;


### PR DESCRIPTION
This pull request tries to adress some problematic server-url arguments.

Before, URLs for servers, that do not use a separate port for the REST API did not work at all, because the coerceOptions function would append `:12900` after the `/api/` part in a url like `http://graylog-server.internal:9000/api`.

With this pull request, such URLs would be left unchanged by the port coercion mechanism.
It unfortunately does not address URLs which omit the port but end in / for example, but this at least makes it possible to use the dashboard with servers that do not use separate ports for the REST API at all.