### PR TITLE
feat(new): add tail for graylog, tailgl

### DIFF
--- a/graylog-dashboard.js
+++ b/graylog-dashboard.js
@@ -29,19 +29,33 @@ const inquirer = require('inquirer');
 const yargs = require('yargs')
   .usage('Usage: $0 <command> [options]')
   .describe('stream-title', 'Graylog Stream Title')
+  .alias('S','stream-title')
   .group(['server-url', 'api-host', 'api-port', 'api-path', 'api-protocol', 'username', 'password'], 'Rest API Options:')
   .describe('server-url', '(Deprecated; use api-host, path, port) Full Graylog API URL')
   .describe('api-host', 'Graylog API Hostname')
+  .alias('H','api-host')
   .describe('api-port', 'Graylog API Port')
   .default('api-port', 9000)
   .describe('api-path', 'Graylog API Path')
   .default('api-path', '/api/')
   .describe('api-protocol', 'Graylog API Protocol')
+  .alias('P','api-protocol')
   .default('api-protocol', 'https')
   .describe('poll-interval', 'How often (in ms) to poll the Graylog server')
   .default('poll-interval', 1000)
   .describe('username', 'Graylog API Username')
+  .alias('u','username')
   .describe('password', 'Graylog API Password')
+  .alias('p','password')
+  .describe('stream-sort', 'Stream Sorting')
+  .default('stream-sort','desc')
+  .describe('query', 'Query')
+  .default('query','*')
+  .alias('Q','query')
+  .describe('fields', 'Fields')
+  .default('fields','timestamp,message')
+  .describe('range', 'Range in seconds')
+  .default('range','86400')
   .describe('cred-file-path', 'Path to an optional credentials file')
   .default('cred-file-path', `${process.env.HOME}/.graylog_dashboard`)
   .describe('insecure', 'If set, will not verify leaf certificates.')
@@ -96,6 +110,7 @@ function getOptions() {
     }
   })
   .then(function coerceOptions() {
+    config.streamSort = config['stream-sort'] || "desc";
     // DEPRECATED: serverURL
     let fullURL = config.serverURL || config['server-url'];
     if (fullURL) {

--- a/lib/graylog-api.js
+++ b/lib/graylog-api.js
@@ -18,6 +18,7 @@
 
 const Promise = require('bluebird');
 const request = require('request');
+const moment = require('moment');
 Promise.promisifyAll(request);
 
 let GRAYLOG_META = null;
@@ -37,15 +38,26 @@ module.exports = {
   },
 
   lastMessagesOfStream(options) {
-    const url = `${options.serverURL}search/universal/relative`;
+    var fields = options.fields.split(',');
+    if (!fields.includes('_id')) { fields.unshift('_id'); }
+    if (!fields.includes('timestamp')) { fields.unshift('timestamp'); }
     const parameters = {
       query: options.query,
-      range: options.range,
-      fields: options.fields,
+      fields: fields.join(','),
       filter: "streams:" + options.streamID,
-      sort: "timestamp:" + options.streamSort,
-      limit: 50
+      sort: options.sort,
+      limit: options.batch
     };
+    let url;
+    if (options.last_timestamp) {
+      url = `${options.serverURL}search/universal/absolute`;
+      parameters.from = options.last_timestamp;
+      parameters.to = moment().toISOString(); // now
+    }
+    else {
+      url = `${options.serverURL}search/universal/relative`;
+      parameters.range = options.range;
+    }
 
     // In 2.3 / ElasticSearch > 5.5 this was changed to `stored_fields`
     // https://github.com/Graylog2/graylog2-server/issues/4042

--- a/lib/graylog-api.js
+++ b/lib/graylog-api.js
@@ -39,11 +39,11 @@ module.exports = {
   lastMessagesOfStream(options) {
     const url = `${options.serverURL}search/universal/relative`;
     const parameters = {
-      query: "*",
-      range: 86400,
-      fields: "timestamp,message",
+      query: options.query,
+      range: options.range,
+      fields: options.fields,
       filter: "streams:" + options.streamID,
-      sort: 'timestamp:asc',
+      sort: "timestamp:" + options.streamSort,
       limit: 50
     };
 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     }
   ],
   "dependencies": {
+    "ansi": "^0.3.1",
     "blessed": "^0.1.81",
     "blessed-contrib": "^4.5.5",
     "bluebird": "^3.4.6",
@@ -35,7 +36,8 @@
   },
   "preferGlobal": "true",
   "bin": {
-    "graylog-dashboard": "graylog-dashboard.js"
+    "graylog-dashboard": "graylog-dashboard.js",
+    "tailgl": "tailgl.js"
   },
   "devDependencies": {
     "eslint": "^3.9.0",

--- a/tailgl.js
+++ b/tailgl.js
@@ -20,9 +20,10 @@
 
 const Promise = require('bluebird');
 const graylog = require('./lib/graylog-api');
-const ui = require('./lib/screen');
+const moment = require('moment');
+const ansi = require('ansi');
+const cursor = ansi(process.stdout);
 const url = require('url');
-const handlers = require('./lib/handlers');
 const fs = require('fs');
 const yaml = require('js-yaml');
 const inquirer = require('inquirer');
@@ -53,11 +54,13 @@ const yargs = require('yargs')
   .default('query','*')
   .alias('Q','query')
   .describe('fields', 'Fields')
-  .default('fields','timestamp,message')
+  .default('fields','timestamp,source,message')
   .describe('range', 'Range in seconds')
   .default('range','86400')
   .describe('batch', 'events per request')
   .default('batch','50')
+  .describe('format','output format (ansi,csv,json)')
+  .default('format','ansi')
   .describe('cred-file-path', 'Path to an optional credentials file')
   .default('cred-file-path', `${process.env.HOME}/.graylog_dashboard`)
   .describe('insecure', 'If set, will not verify leaf certificates.')
@@ -66,6 +69,53 @@ const yargs = require('yargs')
 // Will contain:
 // username, password, host, streamID, pollInterval, credFilePath
 let config;
+
+function updateMessagesList(messages) {
+
+  const fields = config.fields.split(',');
+
+  const items = messages
+  .sort((message1, message2) => new Date(message1.timestamp) - new Date(message2.timestamp));
+
+  let msg;
+  while(items.length) {
+    let values = [], line;
+    msg = items.shift()
+    // skip if _id already displayed
+    if (config.id_blacklist[ msg['_id'] ]) { continue; }
+    fields.forEach(function(el) {
+      switch(el){
+        case 'timestamp':
+          cursor.grey().write( moment(msg.timestamp).format('YYYY-MM-DD HH:mm:ss') );
+          break;
+        case 'source':
+          cursor.yellow().write( ' '+ msg.source );
+          break;
+        default:
+          cursor.reset().write( ' '+ msg[el] );
+      }
+    });
+    cursor.write('\n');
+
+    // blacklist displayed message-ids in order to prevent successive
+    // results from the same second from being re-displayed 
+    config.id_blacklist[ msg['_id'] ] = msg.timestamp;
+  }
+  
+  // save last msg id and last timestamp
+  if (msg) {
+    config.last_id = msg['_id'];
+    config.last_timestamp = msg.timestamp;
+  }
+
+  // clean id_blacklist
+  for (var id in config.id_blacklist) {
+    if ( new Date(config.id_blacklist[id]) < new Date(config.last_timestamp) ) {
+      delete config.id_blacklist[id];
+    }
+  }
+}
+
 
 function getOptions() {
   return Promise.try(function getOptionInput() {
@@ -112,7 +162,9 @@ function getOptions() {
     }
   })
   .then(function coerceOptions() {
-    config.sort = config['sort'] || "timestamp:desc";
+    // inital value
+    config.id_blacklist = {}
+
     // DEPRECATED: serverURL
     let fullURL = config.serverURL || config['server-url'];
     if (fullURL) {
@@ -143,24 +195,12 @@ function storeStreams(_streams) {
   }
   const thisStream = streams.find((s) => s.title === config.streamTitle);
   config.streamID = thisStream.id;
-  ui.flush(thisStream.title, streams);
-}
-
-function onStreamChange(blessedEl) {
-  const streamTitle = blessedEl.content;
-  config.streamTitle = streamTitle;
-  config.streamID = streams.find((s) => s.title === streamTitle).id;
-  ui.flush(streamTitle, streams);
 }
 
 function poll() {
   return Promise.all([
-    graylog.lastMessagesOfStream(config).then(handlers.updateMessagesList),
-    graylog.streamThroughput(config).then(handlers.updateStreamThroughput),
-    graylog.totalThroughput(config).then(handlers.updateTotalThroughputLine),
-    graylog.streamAlerts(config).then(handlers.renderAlerts),
+    graylog.lastMessagesOfStream(config).then(updateMessagesList),
   ])
-  .then(() => ui.render()) // batch up renders
   .delay(config.pollInterval)
   .then(() => poll(config.streamID));
 }
@@ -168,9 +208,6 @@ function poll() {
 // Entry
 getOptions()
 .then(graylog.getMetadata)
-.then(() => ui.create({onStreamChange}))
 .then(() => graylog.streams(config))
 .tap(storeStreams)
-.then(handlers.updateStreamsList)
-.then(poll)
-.catch((e) => { ui.screen && ui.screen.destroy(); console.error(e); process.exit(1); });
+.then(poll);


### PR DESCRIPTION
This PR adds a program called `tailgl` that enables tailing graylogs from workstation command line.   Any suggestions for code or style improvements are welcome.

If this addition is acceptable, happy to update the readme as well.

Example of use:
```tailgl -Q "source:hostname"```